### PR TITLE
Minor/automate testing

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,9 @@
 name: Pull Request
 
-on: pull_request:
-  branches:
-    - main
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,29 @@
+name: Pull Request
+
+on: pull_request:
+  branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Analysing the code with pre-commit lint checks
+      run: |
+        pre-commit run -a
+    - name: Test code
+      run: |
+        tox
+

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  Lint Code:
+  lint_code:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,7 +25,7 @@ jobs:
       run: |
         pre-commit run -a
 
-  Test Code:
+  test_code:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,11 +6,11 @@ on:
       - main
 
 jobs:
-  build:
+  Lint Code:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -24,6 +24,22 @@ jobs:
     - name: Analysing the code with pre-commit lint checks
       run: |
         pre-commit run -a
+
+  Test Code:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
     - name: Test code
       run: |
         tox

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ ENV/
 
 # IDE settings
 .vscode/.git.old
+*.swp
+
+# macOS temporary files
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: "23.12.1"
     hooks:
       - id: black

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,8 @@ sphinx
 sphinx-gallery
 sphinx_rtd_theme
 numpydoc
+
+# for development
+tox
+ruff
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,3 @@ sphinx
 sphinx-gallery
 sphinx_rtd_theme
 numpydoc
-
-# for development
-tox
-ruff
-pre-commit

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "matplotlib",
         "obsarray",
     ],
-    extras_require={"dev": ["pre-commit", "tox", "sphinx", "sphinx_rtd_theme"]},
+    extras_require={"dev": ["pre-commit", "tox", "ruff", "sphinx", "sphinx_rtd_theme"]},
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,13 @@ import re
 
 from setuptools import find_packages
 from setuptools import setup
-exec(open('comet_maths/_version.py').read())
+
+exec(open("comet_maths/_version.py").read())
+
 
 def read(filename):
     filename = os.path.join(os.path.dirname(__file__), filename)
-    text_type = type(u"")
+    text_type = type("")
     with io.open(filename, mode="r", encoding="utf-8") as fd:
         return re.sub(text_type(r":[a-z]+:`~?(.*?)`"), text_type(r"``\1``"), fd.read())
 
@@ -23,7 +25,15 @@ setup(
     description="Mathematical algorithms and tools to use within CoMet toolkit.",
     long_description=read("README.rst"),
     packages=find_packages(exclude=("tests",)),
-    install_requires=["numpy","scikit-learn","numdifftools","scipy","punpy","matplotlib","obsarray"],
+    install_requires=[
+        "numpy",
+        "scikit-learn",
+        "numdifftools",
+        "scipy",
+        "punpy",
+        "matplotlib",
+        "obsarray",
+    ],
     extras_require={"dev": ["pre-commit", "tox", "sphinx", "sphinx_rtd_theme"]},
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
This adds linting (using ruff) and code testing (using tox) in a GitHub action during the pull request stage.

Fixing black pre-commit version. This is recommended [here](https://pre-commit.com//#using-the-latest-version-for-a-repository). Although I would recommend replacing black with ruff in the pre-commit hooks (this collates each black, isort and flake8 and is written in speedy rust).

I also added ruff as a development requirement to `setup.py`.

