### PR TITLE
Division by zero patch in correlation

### DIFF
--- a/comet_maths/linear_algebra/matrix_conversion.py
+++ b/comet_maths/linear_algebra/matrix_conversion.py
@@ -29,7 +29,11 @@ def correlation_from_covariance(covariance: np.ndarray) -> np.ndarray:
     if covariance is not None:
         v = np.sqrt(np.diag(covariance))
         outer_v = np.outer(v, v)
-        correlation = covariance / outer_v
+        correlation = np.divide(
+            covariance,
+            outer_v,
+            where=outer_v != 0
+        )
         correlation[covariance == 0] = 0
         return correlation
 


### PR DESCRIPTION
I was hitting runtime errors with this step when the denominator was zero.

I have added a wrapper to divide safely.